### PR TITLE
Oldest Olympians Endpoint

### DIFF
--- a/app/controllers/api/v1/olympians_controller.rb
+++ b/app/controllers/api/v1/olympians_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::OlympiansController < ApplicationController
     when 'youngest'
       parse_olympians(Olympian.youngest)
     when 'oldest'
-      binding.pry
+      parse_olympians(Olympian.oldest)
     else
       { message: "Age must be 'youngest' or 'oldest'!" } 
     end

--- a/app/models/olympian.rb
+++ b/app/models/olympian.rb
@@ -44,4 +44,19 @@ class Olympian < ApplicationRecord
     .group('olympians.id, teams.name, sports.name')
     .where(age: Olympian.minimum(:age))
   end
+
+  def self.oldest    
+    select('
+      olympians.name, 
+      olympians.sex, 
+      olympians.age, 
+      teams.name as team, 
+      sports.name as sport, 
+      COUNT(medalists.*) AS total_medals_won
+    ')
+    .joins(:team, :sports)
+    .left_joins(:medalists)
+    .group('olympians.id, teams.name, sports.name')
+    .where(age: Olympian.maximum(:age))
+  end
 end

--- a/spec/requests/api/v1/olympians/index_spec.rb
+++ b/spec/requests/api/v1/olympians/index_spec.rb
@@ -114,6 +114,30 @@ describe 'Olympians Index:', type: :request do
       expect(response[:olympians][1]).to have_key(:total_medals_won)
       expect(response[:olympians][1][:total_medals_won]).to eq(0)
     end
+
+    it 'I get a JSON response with the oldest olympians in the database' do
+      get '/api/v1/olympians?age=oldest'
+
+      response = JSON.parse(@response.body, symbolize_names: true)
+      response[:olympians] = response[:olympians].sort_by { |olympian| olympian[:name] }
+
+      expect(@response.status).to eq(200)
+      expect(response).to have_key(:olympians)
+      expect(response[:olympians]).to be_an(Array)
+      expect(response[:olympians].length).to eq(1)
+
+      expect(response[:olympians][0]).to have_key(:name)
+      expect(response[:olympians][0][:name]).to eq('Veronica')
+      expect(response[:olympians][0]).to have_key(:team)
+      expect(response[:olympians][0][:team]).to eq('Spain')
+      expect(response[:olympians][0]).to have_key(:age)
+      expect(response[:olympians][0][:age]).to eq(32)
+      expect(response[:olympians][0]).to have_key(:sport)
+      expect(response[:olympians][0][:sport]).to eq('Pole Vaulting')
+      expect(response[:olympians][0]).to have_key(:total_medals_won)
+      expect(response[:olympians][0][:total_medals_won]).to eq(1)
+    end
+
     it 'returns an error message if age is not youngest' do
       get '/api/v1/olympians?age=asdf'
 


### PR DESCRIPTION
* Add query parameter to `GET /api/v1/olympians?age=oldest` in order to get back the oldest Olympians.

closes #12 